### PR TITLE
Some "convenience" additions and some changes to make auditing module work on Windows Server 2019

### DIFF
--- a/WDACAuditing.psm1
+++ b/WDACAuditing.psm1
@@ -199,6 +199,10 @@ Specifies that events should only be returned since the last time the code integ
 
 Specifies that correlated signer and WHQL events should be collected. When there are many CodeIntegrity events present in the event log, collection of signer and WHQL events can be very time consuming.
 
+.PARAMETER IgnoreNativeImagesDLLs
+
+Specifies that events where ResolvedFilePath is like "$env:SystemRoot\assembly\NativeImages*.dll" should be skipped. Usefull to suppress events caused by auto-generated "NativeImages DLLs"
+
 .PARAMETER MaxEvents
 
 Specifies the maximum number of events that Get-WDACCodeIntegrityEvent returns. The default is to return all the events.
@@ -247,6 +251,9 @@ Return all kernel mode enforcement events.
 
         [Switch]
         $SignerAndWhqlChecks,
+
+        [Switch]
+        $IgnoreNativeImagesDLLs,
 
         [Int64]
         $MaxEvents
@@ -443,6 +450,8 @@ Return all kernel mode enforcement events.
             SignerInfo = $ResolvedSigners
         }
 
-        New-Object -TypeName PSObject -Property $CIEventProperties
+        if (-not $IgnoreNativeImagesDLLs -or ($IgnoreNativeImagesDLLs -and $CIEventProperties.ResolvedFilePath -notlike "$env:SystemRoot\assembly\NativeImages*.dll")) {
+            New-Object -TypeName PSObject -Property $CIEventProperties
+        }
     }
 }


### PR DESCRIPTION
Some changes are pure convenience, and others are to make auditing functions work on Windows Server 2019.

1. Changes ```Get-WDACCodeIntegrityEvent``` to return a NULL value for PolicyGUID if event data does not supply one (quick'n'dirty fix to make function work on Windows Server 2019)
2. Adds ```Get-WinEventData``` function that creates a pscustomobject with named properties based on the referenced event template. This makes it easier to discover and reference available data from an event.
3. Adds ```Get-WDACPolicyRefreshEventFilter``` function to lookup last policy refresh, and allow that to be used in ```Get-WDACApplockerScriptMsiEvent``` as well.
4. Changes ```Get-WDACCodeIntegrityEvent``` and ```Get-WDACApplockerScriptMsiEvent``` to use the two new functions.
5. Adds a ```-SinceLastPolicyRefresh``` to ```Get-WDACApplockerScriptMsiEvent``` to only get events since last policy refresh
6. Adds a ```-IgnoreNativeImagesDLLs``` switch to ```Get-WDACCodeIntegrityEvent``` to skip those ```*.ni.dll``` "false positive" events from showing.

Code will need a bit of reviewing to ensure I still pick the right properties from event data, and the name of the ```-IgnoreNativeImagesDLLs``` is definitely open for debate. Speaking of that switch, the implementation is a bit of a quick'n'dirty hack as well - a nicer implementation could be made, that skipped those events earlier on to speed up processing time, but that would require more of a rewrite, and I wanted to check with you first before optionally doing that.

Let me know what you think of the changes - I am totally open to changing what I have made, if you don't agree with the approach, style, naming or what have you :)

Thoughts?