### PR TITLE
Only look up SIDs as found in logs

### DIFF
--- a/WDACAuditing.psm1
+++ b/WDACAuditing.psm1
@@ -249,10 +249,6 @@ Get-WDACApplockerScriptMsiEvent -SignerInformation
         8037 = 'Allowed'
     }
 
-    # Resolve user names from SIDs
-    $UserMapping = @{}
-    Get-CimInstance Win32_Account -Property SID, Caption | ForEach-Object { $UserMapping[$_.SID] = $_.Caption }
-
     Get-WinEvent -LogName 'Microsoft-Windows-AppLocker/MSI and Script' -FilterXPath $Filter @MaxEventArg -ErrorAction Ignore | ForEach-Object {
         $ResolvedSigners = $null
         $SigningStatus = $null

--- a/WDACAuditing.psm1
+++ b/WDACAuditing.psm1
@@ -10,6 +10,7 @@ if ($PartitionMapping.Count -eq 0) {
 }
 
 # Resolve user names from SIDs
+$Script:UserMapping = @{}
 function Get-UserMapping {
     [CmdletBinding()]
     param (
@@ -17,10 +18,6 @@ function Get-UserMapping {
         [Parameter(Mandatory)]
         [System.Security.Principal.SecurityIdentifier]$SID
     )
-
-    if (-not $UserMapping) {
-        $Script:UserMapping = @{}
-    }
 
     if (-not ($UserMapping[$SID.Value])) {
         $Account = Get-CimInstance Win32_Account -Property SID, Caption -Filter ('SID="{0}"' -f $SID.Value)

--- a/WDACAuditing.psm1
+++ b/WDACAuditing.psm1
@@ -11,21 +11,6 @@ if ($PartitionMapping.Count -eq 0) {
 
 # Resolve user names from SIDs
 $Script:UserMapping = @{}
-function Get-UserMapping {
-    [CmdletBinding()]
-    param (
-        # Security identifier of the account to look up
-        [Parameter(Mandatory)]
-        [System.Security.Principal.SecurityIdentifier]$SID
-    )
-
-    if (-not ($UserMapping[$SID.Value])) {
-        $Account = Get-CimInstance Win32_Account -Property SID, Caption -Filter ('SID="{0}"' -f $SID.Value)
-        # Revert to the SID if a user name cannot be resolved
-        $UserMapping[$SID.Value] = if ($Account.Caption) {$Account.Caption} else {$SID.Value}
-    }
-    $UserMapping[$SID.Value]
-}
 
 $Script:Providers = @{
     'Microsoft-Windows-AppLocker'     = (Get-WinEvent -ListProvider Microsoft-Windows-AppLocker)
@@ -101,6 +86,22 @@ $Script:VerificationErrorMapping = @{
     [Byte] 26 = 'Explicitly denied by WDAC policy'
     [Byte] 27 = 'The signing chain appears to be tampered/invalid'
     [Byte] 28 = 'Resource page hash mismatch'
+}
+
+function Get-UserMapping {
+    [CmdletBinding()]
+    param (
+        # Security identifier of the account to look up
+        [Parameter(Mandatory)]
+        [System.Security.Principal.SecurityIdentifier]$SID
+    )
+
+    if (-not ($UserMapping[$SID.Value])) {
+        $Account = Get-CimInstance Win32_Account -Property SID, Caption -Filter ('SID="{0}"' -f $SID.Value)
+        # Revert to the SID if a user name cannot be resolved
+        $UserMapping[$SID.Value] = if ($Account.Caption) {$Account.Caption} else {$SID.Value}
+    }
+    $UserMapping[$SID.Value]
 }
 
 function Get-WDACPolicyRefreshEventFilter {

--- a/WDACAuditing.psm1
+++ b/WDACAuditing.psm1
@@ -15,19 +15,19 @@ function Get-UserMapping {
     param (
         # Security identifier of the account to look up
         [Parameter(Mandatory)]
-        [string]$SID
+        [System.Security.Principal.SecurityIdentifier]$SID
     )
 
     if (-not $UserMapping) {
         $Script:UserMapping = @{}
     }
 
-    if (-not ($UserMapping[$SID])) {
-        $Account = Get-CimInstance Win32_Account -Property SID, Caption -Filter "SID='$SID'"
+    if (-not ($UserMapping[$SID.Value])) {
+        $Account = Get-CimInstance Win32_Account -Property SID, Caption -Filter ('SID="{0}"' -f $SID.Value)
         # Revert to the SID if a user name cannot be resolved
-        $UserMapping[$SID] = if ($Account.Caption) {$Account.Caption} else {$SID}
+        $UserMapping[$SID.Value] = if ($Account.Caption) {$Account.Caption} else {$SID.Value}
     }
-    $UserMapping[$SID]
+    $UserMapping[$SID.Value]
 }
 
 $Script:Providers = @{

--- a/WDACAuditing.psm1
+++ b/WDACAuditing.psm1
@@ -10,9 +10,13 @@ if ($PartitionMapping.Count -eq 0) {
 }
 
 # Resolve user names from SIDs
-$Script:UserMapping = @{}
+function Get-UserMapping {
+    if (-not $UserMapping) {
+        $Script:UserMapping = @{}
 
-Get-CimInstance Win32_Account -Property SID, Caption | ForEach-Object { $UserMapping[$_.SID] = $_.Caption }
+        Get-CimInstance Win32_Account -Property SID, Caption | ForEach-Object { $UserMapping[$_.SID] = $_.Caption }
+    }
+}
 
 $Script:Providers = @{
     'Microsoft-Windows-AppLocker'     = (Get-WinEvent -ListProvider Microsoft-Windows-AppLocker)
@@ -248,6 +252,9 @@ Get-WDACApplockerScriptMsiEvent -SignerInformation
         8029 = 'Enforce'
         8037 = 'Allowed'
     }
+
+    # Resolve user names from SIDs
+    Get-UserMapping
 
     Get-WinEvent -LogName 'Microsoft-Windows-AppLocker/MSI and Script' -FilterXPath $Filter @MaxEventArg -ErrorAction Ignore | ForEach-Object {
         $ResolvedSigners = $null
@@ -485,6 +492,9 @@ Return all kernel mode enforcement events.
         [UInt32] 0 = 'Driver'
         [UInt32] 1 = 'UserMode'
     }
+
+    # Resolve user names from SIDs
+    Get-UserMapping
 
     $MaxEventArg = @{}
 


### PR DESCRIPTION
`Get-CimInstance Win32_Account` can be very slow, so start by delaying it until `Get-WDACApplockerScriptMsiEvent` or `Get-WDACCodeIntegrityEvent` is used rather than doing it at module import. 
I then switched to only looking up SIDs as they were found in the logs rather than looking up all domain accounts to save time, since generally only a relatively small number of accounts appear in the logs.